### PR TITLE
Added support for breadcrumbs interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,37 @@ A Clojure library to send events to a sentry host.
 The main exported function is `capture!` and has two arities:
 
 - `(capture! dsn event)`: Send a capture over the network, see the description of DSN and ev below.
-- `(capture! client dsn event)`: Use the provided http client (as built by `net.http.client/http-client` from https://github.com/pyr/net.
+- `(capture! client dsn event)`: Use the provided http client (as built by `net.http.client/http-client` from https://github.com/pyr/net).
 
 #### Arguments
 
-**DSN**: A Sentry DSN as defined http://sentry.readthedocs.org/en/2.9.0/client/index.html#parsing-the-dsn
-**Event**: Either an exception or a map
+- **DSN**: A Sentry DSN as defined http://sentry.readthedocs.org/en/2.9.0/client/index.html#parsing-the-dsn
+- **Event**: Either an exception or a map
+
+#### Breadcrumbs
+
+Adding sentry "breadcrumbs" can be done using the `add-breadcrumb!` function,
+that has the following arities:
+
+- `(add-breadcrumb! message category)` The created breadcrumb has a level of
+  "info"
+- `(add-breadcrumb! message category level)` Allows you to specify the desired
+  breadcrumb "level". Level can be one of: `["debug" "info" "warning" "warn" "error" "exception" "critical" "fatal"]`
+- `(add-breadcrumb! message category level timestamp)` Allows you to pass in a
+  specific timestamp for the breadcrumb you are creating.
+
+Please note that the breadcrums use thread-local storage, and therefore might
+be ill-suited for some use cases.
+
+More information can be found on [Sentry's documentation website](https://docs.sentry.io/clientdev/interfaces/breadcrumbs/)
 
 ### Changelog
+
+#### unreleased
+
+- Added support for breadcrumbs
+- Added specs for wire format (JSON)
+- Code cleanup
 
 #### 0.1.4
 

--- a/src/raven/spec.clj
+++ b/src/raven/spec.clj
@@ -1,7 +1,43 @@
 (ns raven.spec
-  "specifications for the wire JSON structure when talking to sentry."
+  "Specifications for the wire JSON structure when talking to sentry."
   (:require [clojure.spec.alpha :as s]))
+
+(def valid-levels
+  "A list of valid message levels."
+  ["debug" "info" "warning" "warn" "error" "exception" "critical" "fatal"])
+
+(def valid-types
+  "A list of valid breadcrumbs types."
+  ;; TODO: support the other types of breadcrumbs as well.
+  ;;["default" "navigation" "http"]
+  ["default"])
+
+(defn is-valid-type?
+  [typ]
+  (some #(= % typ) valid-types))
+
+(defn is-valid-level?
+  [lvl]
+  (some #(= % lvl) valid-levels))
+
+(defn is-valid-platform?
+  "Only one platform choice is valid for clojure."
+  [platform]
+  (= platform "java"))
+
+;; timestamp is expected to be "the number of seconds since the epoch", with a
+;; precision of a millisecond.
+(s/def ::timestamp float?)
+(s/def ::type is-valid-type?)
+(s/def ::level is-valid-level?)
+(s/def ::message string?)
+(s/def ::sever_name string?)
+(s/def ::culprit string?)
+(s/def ::platform is-valid-platform?)
+(s/def ::breadcrumb (s/keys :req-un [::type ::timestamp ::level ::message ::category]))
+(s/def ::values (s/coll-of ::breadcrumb))
+(s/def ::breadcrumbs (s/keys :req-un [::values]))
 
 ;; We declare the message spec in the raven.client namespace to allow easy
 ;; reference from there (simply "::payload" when using the spec).
-(s/def :raven.client/payload (s/keys :req-un [::level ::server_name ::timestamp ::platform]))
+(s/def :raven.client/payload (s/keys :req-un [::event_id ::culprit ::level ::server_name ::timestamp ::platform] :opt-un [::breadcrumbs]))

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -20,11 +20,40 @@
 (def frozen-uuid
   "a059419cd1bd46a685b95080f260aed4")
 
+(def frozen-servername
+  "Muninn")
+
+(def expected-message
+  "a test message")
+
 (def expected-header
   (str "Sentry sentry_version=2.0, sentry_signature=" expected-sig ", sentry_timestamp=" frozen-ts ", sentry_client=spootnik-raven/0.1.4, sentry_key=" (:key expected-parsed-dsn)))
 
 (def expected-payload
-  (str "{\"level\":\"error\",\"server_name\":\"matterhorn\",\"culprit\":\"<none>\",\"timestamp\":" frozen-ts ",\"platform\":\"java\",\"event_id\":\"" frozen-uuid "\",\"project\":42}"))
+  {:level "error"
+   :server_name frozen-servername
+   :culprit "<none>"
+   :timestamp frozen-ts
+   :platform "java"
+   :event_id frozen-uuid
+   :project 42
+   :message expected-message})
+
+(def expected-breadcrumb
+  {:type "default"
+   :timestamp frozen-ts
+   :level "info"
+   :message "message"
+   :category "category"})
+
+(defn reset-breadcrumbs
+  "A fixture to reset the per-thread atom to an empty list between tests.."
+  [f]
+  (do
+    (f)
+    (clear-breadcrumbs)))
+
+(use-fixtures :each reset-breadcrumbs)
 
 (deftest raven-client-tests
   (testing "parsing DSN"
@@ -37,4 +66,33 @@
     (is (= (auth-header frozen-ts (:key expected-parsed-dsn) expected-sig) expected-header)))
 
   (testing "the payload is constructed from a map"
-    (is (= expected-payload (payload {} frozen-ts 42 frozen-uuid)))))
+    (is (= expected-payload (payload {:message expected-message} frozen-ts 42 frozen-uuid frozen-servername))))
+
+  (testing "the payload is constructed from a string"
+    (is (= expected-payload (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))
+
+(deftest gather-breadcrumbs
+  (testing "we can gather breadcrumbs"
+    (do
+      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (is (= [expected-breadcrumb] @@breadcrumbs)))))
+
+(deftest add-breadcrumbs
+  (testing "breadcrumbs are added to the payload"
+    (do
+      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (is (= expected-breadcrumb (first (:values (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
+
+(deftest multi-breadcrumbs
+  (testing "adding several breadcrumbs to the payload"
+    (do
+      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (is (= 2 (count (:values (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
+
+(deftest multi-thread
+  (testing "breadcrumbs are thread local"
+    (do
+      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (is (nil? @(future (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername))))))))


### PR DESCRIPTION
- Added a new "add-breadcrumb!" function storing breadcrumbs in
thread-local storage. Breadcrumbs are sent along with the next invocation of
"capture!".
- Expanded specification of the wire structure to include breadcrumbs.
- Added tests.
- Expanded README with breadcrumbs usage.