### PR TITLE
Change breadcrumbs api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The main exported function is `capture!` and has two arities:
 
 - **DSN**: A Sentry DSN as defined http://sentry.readthedocs.org/en/2.9.0/client/index.html#parsing-the-dsn
 - **Event**: Either an exception or a map.
-- **Context**: A map of aditional informations you can pass to Sentry. Note
+- **Context**: A map of additional information you can pass to Sentry. Note
   that omitting this parameter will make use of some thread-local storage for
   some of the functionality.
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,32 @@ The main exported function is `capture!` and has two arities:
 Adding sentry "breadcrumbs" can be done using the `add-breadcrumb!` function,
 that has the following arities:
 
-- `(add-breadcrumb! message category)` The created breadcrumb has a level of
-  "info"
-- `(add-breadcrumb! message category level)` Allows you to specify the desired
-  breadcrumb "level". Level can be one of: `["debug" "info" "warning" "warn" "error" "exception" "critical" "fatal"]`
-- `(add-breadcrumb! message category level timestamp)` Allows you to pass in a
-  specific timestamp for the breadcrumb you are creating.
+- `(add-breadcrumb! breadcrumb)` Store a breadcrumb in thread-local storage.
+- `(add-breadcrumb! context breadcrumb)` Store a breadcrumb in a user-specified
+context. Context is expected to be map-like.
 
-Please note that the breadcrums use thread-local storage, and therefore might
-be ill-suited for some use cases.
+Well-formatted breadcrumb maps can be created with the `make-breadcrumb!`
+helper, with the following arities:
+
+- `(make-breadcrumb! message category)` A breadcrumb will be created with the
+  "info" level.
+- `(make-breadcrumb! message category level)` This allows specifying a level.
+  Levels can be one of: 'debug' 'info' 'warning' 'warn' 'error' 'exception' 'critical' 'fatal'
+- `(make-breadcrumb! message category level timestamp)` This allows setting a
+  custom timestamp instead of letting the helper get one for you. Timestamp
+  must be a floating point representation of **seconds** elapsed since the
+  epoch (not milliseconds).
 
 More information can be found on [Sentry's documentation website](https://docs.sentry.io/clientdev/interfaces/breadcrumbs/)
+
+#### Full example
+
+```clojure
+(def dsn "https://098f6bcd4621d373cade4e832627b4f6:ad0234829205b9033196ba818f7a872b@sentry.example.com/42")
+(add-breadcrumb! (make-breadcrumb! "The user did something" "com.example.Foo"))
+(add-breadcrumb! (make-breadcrumb! "The user did something wrong" "com.example.Foo" "error"))
+(capture! dsn (Exception.))
+```
 
 ### Changelog
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,25 @@ A Clojure library to send events to a sentry host.
 The main exported function is `capture!` and has two arities:
 
 - `(capture! dsn event)`: Send a capture over the network, see the description of DSN and ev below.
-- `(capture! client dsn event)`: Use the provided http client (as built by `net.http.client/http-client` from https://github.com/pyr/net).
+- `(capture! context dsn event)`: Send a capture passing additional context, such as a specific HTTP client.
 
 #### Arguments
 
 - **DSN**: A Sentry DSN as defined http://sentry.readthedocs.org/en/2.9.0/client/index.html#parsing-the-dsn
-- **Event**: Either an exception or a map
+- **Event**: Either an exception or a map.
+- **Context**: A map of aditional informations you can pass to Sentry. Note
+  that omitting this parameter will make use of some thread-local storage for
+  some of the functionality.
+
+#### Passing your own http instance
+
+In many cases, it makes sense to reuse an already existing http client (created
+with http/build-client). Raven will reuse an http instance if it is passed to
+the (capture!) function through the `context` parameter, as :http.
+
+```clojure
+(capture! {:http (http/build-client {})} "<dsn>" "My message")
+```
 
 #### Breadcrumbs
 

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -149,10 +149,7 @@
 (defn add-breadcrumbs-to-payload
   [context payload]
   (let [breadcrumbs-list (:breadcrumbs context)]
-    (merge payload
-           (cond
-             (empty? breadcrumbs-list)  {}
-             :else   {:breadcrumbs {:values breadcrumbs-list}}))))
+    (cond-> payload (seq breadcrumbs-list) (assoc :breadcrumbs {:values breadcrumbs-list}))))
 
 (defn validate-payload
   "Returns a validated payload."

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -191,9 +191,7 @@
     We expect callers to pass the http client in the context object at the
     :http key."
   [context]
-  (cond
-    (contains? context :http)   (:http context)
-    :else                       (http/build-client {})))
+  (or (:http context) (http/build-client {})))
 
 (defn capture!
   "Send a capture over the network. If `ev` is an exception,

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -242,7 +242,8 @@
   "
   ([breadcrumb]
    ;; We need to dereference to get the atom since "thread-storage" is thread-local.
-   (swap! @thread-storage (fn [x] (update x :breadcrumbs conj breadcrumb))))
+   (swap! @thread-storage add-breadcrumb! breadcrumb))
+
   ([context breadcrumb]
    ;; We add the breadcrumb to the context instead, in a ":breadcrumb" key.
    (update context :breadcrumbs conj breadcrumb)))

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -74,25 +74,25 @@
 (deftest gather-breadcrumbs
   (testing "we can gather breadcrumbs"
     (do
-      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
-      (is (= [expected-breadcrumb] @@breadcrumbs)))))
+      (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
+      (is (= [expected-breadcrumb] (:breadcrumbs @@thread-storage))))))
 
 (deftest add-breadcrumbs
   (testing "breadcrumbs are added to the payload"
     (do
-      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
       (is (= expected-breadcrumb (first (:values (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
 
 (deftest multi-breadcrumbs
   (testing "adding several breadcrumbs to the payload"
     (do
-      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
-      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
+      (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
       (is (= 2 (count (:values (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
 
 (deftest multi-thread
   (testing "breadcrumbs are thread local"
     (do
-      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
-      (add-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)
+      (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
+      (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
       (is (nil? @(future (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername))))))))

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -66,10 +66,10 @@
     (is (= (auth-header frozen-ts (:key expected-parsed-dsn) expected-sig) expected-header)))
 
   (testing "the payload is constructed from a map"
-    (is (= expected-payload (payload {:message expected-message} frozen-ts 42 frozen-uuid frozen-servername))))
+    (is (= expected-payload (payload {} {:message expected-message} frozen-ts 42 frozen-uuid frozen-servername))))
 
   (testing "the payload is constructed from a string"
-    (is (= expected-payload (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))
+    (is (= expected-payload (payload {} expected-message frozen-ts 42 frozen-uuid frozen-servername)))))
 
 (deftest gather-breadcrumbs
   (testing "we can gather breadcrumbs"
@@ -81,18 +81,23 @@
   (testing "breadcrumbs are added to the payload"
     (do
       (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
-      (is (= expected-breadcrumb (first (:values (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
+      (is (= expected-breadcrumb (first (:values (:breadcrumbs (payload @@thread-storage expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
 
 (deftest multi-breadcrumbs
   (testing "adding several breadcrumbs to the payload"
     (do
       (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
       (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
-      (is (= 2 (count (:values (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
+      (is (= 2 (count (:values (:breadcrumbs (payload @@thread-storage expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))
 
 (deftest multi-thread
   (testing "breadcrumbs are thread local"
     (do
       (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
       (add-breadcrumb! (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts))
-      (is (nil? @(future (:breadcrumbs (payload expected-message frozen-ts 42 frozen-uuid frozen-servername))))))))
+      (is (nil? @(future (:breadcrumbs (payload @@thread-storage expected-message frozen-ts 42 frozen-uuid frozen-servername))))))))
+
+(deftest manual-context
+  (testing "breadcrumbs are sent using a manual context."
+    (let [context {:breadcrumbs [(make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)]}]
+      (is (= expected-breadcrumb (first (:values (:breadcrumbs (payload context expected-message frozen-ts 42 frozen-uuid frozen-servername)))))))))


### PR DESCRIPTION
This PR changes the library's API to allow for:

- Nicer breadcrumbs API, with "make-breadcrumb!" as a helper to make breadcrumbs.
- Allow passing a context manually (a map) to the "capture!" function and "add-breadcrumb!" functions to avoid using thread-local storage.

The http instance (what used to be the first argument to (capture!) is now passed as the :http key in the context map.