### PR TITLE
Add user interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ The main exported function is `capture!` and has two arities:
 
 - **DSN**: A Sentry DSN as defined http://sentry.readthedocs.org/en/2.9.0/client/index.html#parsing-the-dsn
 - **Event**: Either an exception or a map.
+<<<<<<< HEAD
 - **Context**: A map of additional information you can pass to Sentry. Note
+=======
+- **Context**: A map of aditional informations you can pass to Sentry. Note
+>>>>>>> Add support for explicit context.
   that omitting this parameter will make use of some thread-local storage for
   some of the functionality.
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,35 @@ helper, with the following arities:
 
 More information can be found on [Sentry's documentation website](https://docs.sentry.io/clientdev/interfaces/breadcrumbs/)
 
+#### User
+
+Sentry supports adding information about the user when capturing events. This
+library makes it possible using the `add-user!` function, with the following
+arities:
+
+- `(add-user! user)` Store a user in thread-local storage.
+- `(add-user! context user)` Store a user in a user-specified context. Context
+  is expected to be map-like.
+
+Well-formatted user maps can be created with the `make-user` helper function,
+with the following arities:
+
+- `(make-user id)` A simple user map with the only required field (the user's
+  id) is created.
+- `(make-user id email ip-address username)` A map with all "special"
+  fields recognised by sentry is created. Additional fields can be added to the
+  created user map if desired, and will simply show up in the interface as
+  extra fields.
+
+More information can be found on [Sentry's documentation website](https://docs.sentry.io/clientdev/interfaces/user/)
+
 #### Full example
 
 ```clojure
 (def dsn "https://098f6bcd4621d373cade4e832627b4f6:ad0234829205b9033196ba818f7a872b@sentry.example.com/42")
 (add-breadcrumb! (make-breadcrumb! "The user did something" "com.example.Foo"))
 (add-breadcrumb! (make-breadcrumb! "The user did something wrong" "com.example.Foo" "error"))
+(add-user (make-user "user-id" "test@example.com" "127.0.0.1" "username"))
 (capture! dsn (Exception.))
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ The main exported function is `capture!` and has two arities:
 
 - **DSN**: A Sentry DSN as defined http://sentry.readthedocs.org/en/2.9.0/client/index.html#parsing-the-dsn
 - **Event**: Either an exception or a map.
-<<<<<<< HEAD
 - **Context**: A map of additional information you can pass to Sentry. Note
-=======
-- **Context**: A map of aditional informations you can pass to Sentry. Note
->>>>>>> Add support for explicit context.
   that omitting this parameter will make use of some thread-local storage for
   some of the functionality.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ More information can be found on [Sentry's documentation website](https://docs.s
 
 #### unreleased
 
-- Added support for breadcrumbs
+- Added support for User interface
+- Added support for Breadcrumbs interface
 - Added specs for wire format (JSON)
 - Code cleanup
 

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -36,9 +36,8 @@
 (defn clear-context
   "Reset this thread's context"
   []
-  (do
-    (clear-user)
-    (clear-breadcrumbs)))
+  (clear-user)
+  (clear-breadcrumbs))
 
 (defn md5
   [^String x]

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -165,10 +165,7 @@
 
 (defn add-user-to-payload
   [context payload]
-  (merge payload
-         (cond
-           (contains? context :user) {:user (:user context)}
-           :else {})))
+  (cond-> payload (:user context) (assoc :user (:user context))))
 
 (defn validate-payload
   "Returns a validated payload."
@@ -279,6 +276,5 @@
   "Add user inormation to the sentry context (or a thread-local storage)."
   ([user]
    (swap! @thread-storage add-user! user))
-
   ([context user]
    (assoc context :user user)))

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -240,7 +240,6 @@
   ([breadcrumb]
    ;; We need to dereference to get the atom since "thread-storage" is thread-local.
    (swap! @thread-storage add-breadcrumb! breadcrumb))
-
   ([context breadcrumb]
    ;; We add the breadcrumb to the context instead, in a ":breadcrumb" key.
    (update context :breadcrumbs conj breadcrumb)))

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -273,7 +273,7 @@
     :username username}))
 
 (defn add-user!
-  "Add user inormation to the sentry context (or a thread-local storage)."
+  "Add user information to the sentry context (or a thread-local storage)."
   ([user]
    (swap! @thread-storage add-user! user))
   ([context user]

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -26,12 +26,12 @@
 (defn clear-breadcrumbs
   "Reset this thread's breadcrumbs."
   []
-  (swap! @thread-storage (fn [x] (dissoc x :breadcrumbs))))
+  (swap! @thread-storage dissoc :breadcrumbs))
 
 (defn clear-user
   "Reset this thread's user."
   []
-  (swap! @thread-storage (fn [x] (dissoc x :user))))
+  (swap! @thread-storage dissoc :user))
 
 (defn clear-context
   "Reset this thread's context"

--- a/src/raven/spec.clj
+++ b/src/raven/spec.clj
@@ -37,7 +37,8 @@
 (s/def ::breadcrumb (s/keys :req-un [::type ::timestamp ::level ::message ::category]))
 (s/def ::values (s/coll-of ::breadcrumb))
 (s/def ::breadcrumbs (s/keys :req-un [::values]))
+(s/def ::user (s/keys :req-un [::id] :opt-un [::username ::email ::ip_address]))
 
 ;; We declare the message spec in the raven.client namespace to allow easy
 ;; reference from there (simply "::payload" when using the spec).
-(s/def :raven.client/payload (s/keys :req-un [::event_id ::culprit ::level ::server_name ::timestamp ::platform] :opt-un [::breadcrumbs]))
+(s/def :raven.client/payload (s/keys :req-un [::event_id ::culprit ::level ::server_name ::timestamp ::platform] :opt-un [::breadcrumbs ::user]))


### PR DESCRIPTION
This PR adds a couple of functions to the user API to allow the following:

(add-user! (make-user "myuserID"))
(capture! dsn (Exception.))

This will fill in the "User" sentry interface, displaying information about the user. It is possible to add more information to the User map with either other arities (filling in all the "special" fields Sentry knows about), or passing a normal map with the same or more fields (only the "id" field is required).