### PR TITLE
Cleanup spec for Exception and Stacktrace.

### DIFF
--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -88,9 +88,9 @@
     (cond-> {:message                      (.getMessage e)
              :culprit                      (str (class e))
              :checksum                     (md5 (str (class e)))
-             :sentry.interfaces.Stacktrace {:frames (exception-frames e)}
-             :sentry.interfaces.Exception  {:message   (.getMessage e)
-                                            :type      (str (class e))}}
+             :stacktrace {:frames (exception-frames e)}
+             :exception  {:value  (.getMessage e)
+                          :type   (str (class e))}}
       data (assoc :extra data))))
 
 (def user-agent

--- a/src/raven/spec.clj
+++ b/src/raven/spec.clj
@@ -28,7 +28,8 @@
 ;; timestamp is expected to be "the number of seconds since the epoch", with a
 ;; precision of a millisecond.
 (s/def ::timestamp float?)
-(s/def ::type is-valid-type?)
+(s/def :raven.spec.breadcrumb/type is-valid-type?)
+(s/def :raven.spec.stacktrace/type string?)
 (s/def ::level is-valid-level?)
 (s/def ::message string?)
 (s/def ::sever_name string?)
@@ -36,11 +37,18 @@
 (s/def ::platform is-valid-platform?)
 (s/def ::headers map?)
 (s/def ::env map?)
-(s/def ::breadcrumb (s/keys :req-un [::type ::timestamp ::level ::message ::category]))
+(s/def ::breadcrumb (s/keys :req-un [:raven.spec.breadcrumb/type ::timestamp ::level ::message ::category]))
+(s/def ::frame (s/keys :req-un [::filename ::lineno ::function]))
 (s/def ::values (s/coll-of ::breadcrumb))
+(s/def ::frames (s/coll-of ::frame))
+
+;; The sentry interfaces. We use the alias name instead of the full interface path
+;; as suggested in https://docs.sentry.io/clientdev/interfaces/
 (s/def ::breadcrumbs (s/keys :req-un [::values]))
 (s/def ::user (s/keys :req-un [::id] :opt-un [::username ::email ::ip_address]))
 (s/def ::request (s/keys :req-un [::method ::url] :opt-un [::query_string ::cookies ::headers ::env ::data]))
+(s/def ::stacktrace (s/keys :req-un [::frames]))
+(s/def ::exception (s/keys :req-un [::value :raven.spec.stacktrace/type] :opt-un [::module ::thread_id ::stacktrace ::mechanism]))
 
 ;; We declare the message spec in the raven.client namespace to allow easy
 ;; reference from there (simply "::payload" when using the spec).


### PR DESCRIPTION
- We should use aliases instead of full interface paths (as per sentry
docs).
- Added proper spec validation to both interfaces.