### PR TITLE
Add support for custom fingerprints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ the (capture!) function through the `context` parameter, as :http.
 (capture! {:http (http/build-client {})} "<dsn>" "My message")
 ```
 
+### Extra interfaces
+
 #### Breadcrumbs
 
 Adding sentry "breadcrumbs" can be done using the `add-breadcrumb!` function,
@@ -100,6 +102,23 @@ helper function, with the following arities:
 
 More information about the HTTP interface can be found on [Sentry's
 documentation website](https://docs.sentry.io/clientdev/interfaces/http/).
+
+#### Fingerprints
+
+In cases where you do not send an exception, Sentry will try to group your
+message by looking at differences in interfaces. In some cases, this is not
+enough, and you will want to specify a particular grouping fingerprint, [as
+explained in this part of the Sentry documentation](https://docs.sentry.io/learn/rollups/#custom-grouping).
+
+To set a custom fingerprint for a particular event, this library provides the
+`add-fingerprint!` function with the following arities:
+
+- `(add-fingerprint! fingerprint)` Store the fingerprint in thread-local
+  storage.
+- `(add-fingerprint! context fingerprint)` Store the fingerprint in the
+  user-specified map-like context (expected to be passed to `capture!`).
+
+The contents of the :fingerprint entry is expected to be a list of strings.
 
 #### Full example
 

--- a/src/raven/spec.clj
+++ b/src/raven/spec.clj
@@ -44,6 +44,7 @@
 (s/def ::java (s/keys :req-un [::name ::version]))
 (s/def ::clojure (s/keys :req-un [::name ::version]))
 (s/def ::os (s/keys :req-un [::name ::version] :opt-un [::kernel_version]))
+(s/def ::fingerprint (s/coll-of string?))
 
 ;; The sentry interfaces. We use the alias name instead of the full interface path
 ;; as suggested in https://docs.sentry.io/clientdev/interfaces/
@@ -56,4 +57,4 @@
 
 ;; We declare the message spec in the raven.client namespace to allow easy
 ;; reference from there (simply "::payload" when using the spec).
-(s/def :raven.client/payload (s/keys :req-un [::event_id ::culprit ::level ::server_name ::timestamp ::platform ::contexts] :opt-un [::breadcrumbs ::user ::request]))
+(s/def :raven.client/payload (s/keys :req-un [::event_id ::culprit ::level ::server_name ::timestamp ::platform ::contexts] :opt-un [::breadcrumbs ::user ::request ::fingerprint]))

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -52,6 +52,9 @@
    :message "message"
    :category "category"})
 
+(def expected-fingerprint
+  ["Huginn" "og" "Muninn"])
+
 (def simple-http-info
   {:url "http://example.com"
    :method "POST"})
@@ -146,6 +149,16 @@
 
 (deftest manual-request
   (testing "http information is sent using a manual context"
-
     (let [context {:request (make-http-info (:url simple-http-info) (:method simple-http-info))}]
       (is (= simple-http-info (:request (make-test-payload context)))))))
+
+(deftest add-fingerprint
+  (testing "fingerprints can be added to the payload"
+    (do
+      (add-fingerprint! expected-fingerprint)
+      (is (= expected-fingerprint (:fingerprint (make-test-payload @@thread-storage)))))))
+
+(deftest manual-fingerprint
+  (testing "fingerprints are sent using a manual context"
+    (let [context (add-fingerprint! {} expected-fingerprint)]
+      (is (= expected-fingerprint (:fingerprint (make-test-payload context)))))))


### PR DESCRIPTION
In some cases users of this library might want to pass custom
fingerprints to Sentry. This commit makes it possible.