### PR TITLE
Auto mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,30 @@ DSN=http://... lein test :integration
 This will publish a test event in the project associated with the DSN with as
 much test data as possible.
 
+#### Testing programs using this library
+
+In order to facilitate testing of programs using this library, a special
+":memory:" DSN is supported. When passed to this library in place of a real
+DSN, the payload map that would be sent to sentry in an HTTP request is instead
+stored in the `http-requests-payload-stub` atom.
+
+In your tests, you can assert that a Sentry payload conforming to your
+expectations would have been sent to the sentry server with:
+
+```clojure
+(do
+    (code-that-invokes-capture-once)
+    (is (= 1 (count @http-requests-payload-stub))))
+```
+
+Users are responsible for cleaning the atom up between test runs.
+
 ### Changelog
 
 #### unreleased
 
+- Added special ":memory:" DSN to allow easier testing of programs using this
+  library.
 - Added support for HTTP interface
 - Added support for User interface
 - Added support for Breadcrumbs interface

--- a/src/raven/spec.clj
+++ b/src/raven/spec.clj
@@ -57,4 +57,4 @@
 
 ;; We declare the message spec in the raven.client namespace to allow easy
 ;; reference from there (simply "::payload" when using the spec).
-(s/def :raven.client/payload (s/keys :req-un [::event_id ::culprit ::level ::server_name ::timestamp ::platform ::contexts] :opt-un [::breadcrumbs ::user ::request ::fingerprint]))
+(s/def :raven.client/payload (s/keys :req-un [::event_id ::level ::server_name ::timestamp ::platform ::contexts] :opt-un [::breadcrumbs ::user ::request ::fingerprint ::culprit]))

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -35,11 +35,9 @@
 (def expected-payload
   {:level "error"
    :server_name frozen-servername
-   :culprit "<none>"
    :timestamp frozen-ts
    :platform "java"
    :event_id frozen-uuid
-   :project 42
    :message expected-message})
 
 (def payload-validation-keys
@@ -78,7 +76,7 @@
 
 (defn make-test-payload
   [context]
-  (payload context expected-message frozen-ts 42 frozen-uuid frozen-servername))
+  (payload context expected-message frozen-ts frozen-uuid frozen-servername))
 
 (deftest raven-client-tests
   (testing "parsing DSN"
@@ -162,3 +160,9 @@
   (testing "fingerprints are sent using a manual context"
     (let [context (add-fingerprint! {} expected-fingerprint)]
       (is (= expected-fingerprint (:fingerprint (make-test-payload context)))))))
+
+(deftest capture-with-subbing
+  (testing "we can capture payloads with in-memory stubbing."
+    (do
+      (capture! ":memory:" {:message "This is a stub message"})
+      (is (= "This is a stub message" (:message (first @http-requests-payload-stub)))))))

--- a/test/raven/integration_test.clj
+++ b/test/raven/integration_test.clj
@@ -6,17 +6,17 @@
   (make-http-info "http://example.com" "POST" {:Content-Type "text/html"} "somekey=somevalue" "somecookie=somevalue" "some POST data. This might be BIG!" {:some-env "a value"}))
 
 (defn get-dsn
-    []
-    (let [dsn (System/getenv "DSN")]
-      (if (nil? dsn) 
-        (throw (Exception. "Please provide a 'DSN' environment variable with a valid DSN."))
-        dsn)))
+  []
+  (let [dsn (System/getenv "DSN")]
+    (when (nil? dsn)
+      (throw (Exception. "Please provide a 'DSN' environment variable with a valid DSN.")))
+    dsn))
 
 (deftest ^:integration-test raven-integration-test
   (testing "Sending out a test sentry entry."
-      (add-breadcrumb! (make-breadcrumb! "The user did something" "category.1"))
-      (add-breadcrumb! (make-breadcrumb! "The user did something else" "category.1"))
-      (add-breadcrumb! (make-breadcrumb! "The user did something bad" "category.2" "error"))
-      (add-user! (make-user "123456" "huginn@example.com" "127.0.0.1" "Huginn"))
-      (add-http-info! http-info-map)
-      (capture! (get-dsn) (Exception. "Test exception"))))
+    (add-breadcrumb! (make-breadcrumb! "The user did something" "category.1"))
+    (add-breadcrumb! (make-breadcrumb! "The user did something else" "category.1"))
+    (add-breadcrumb! (make-breadcrumb! "The user did something bad" "category.2" "error"))
+    (add-user! (make-user "123456" "huginn@example.com" "127.0.0.1" "Huginn"))
+    (add-http-info! http-info-map)
+    (capture! (get-dsn) (Exception. "Test exception"))))


### PR DESCRIPTION
This PR (dependent on https://github.com/pyr/raven/pull/13 ) adds functionality that lets users of this library "stub" the network layer easily.

This should allow them to more easily test their code: by setting ":memory:" as DSN, the code is guaranteed to only have in-memory side-effects, that can be further inspected.